### PR TITLE
Create a rust script to subscribe to a mosquitto mqtt broker

### DIFF
--- a/mqtt/rust-mosquitto/Cargo.toml
+++ b/mqtt/rust-mosquitto/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust-mosquitto"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rumqtt = "0.31.0"
+tokio = {version = "1.34.0", features = ["full"]}

--- a/mqtt/rust-mosquitto/Cargo.toml
+++ b/mqtt/rust-mosquitto/Cargo.toml
@@ -5,4 +5,3 @@ edition = "2021"
 
 [dependencies]
 rumqtt = "0.31.0"
-tokio = {version = "1.34.0", features = ["full"]}

--- a/mqtt/rust-mosquitto/src/main.rs
+++ b/mqtt/rust-mosquitto/src/main.rs
@@ -1,0 +1,29 @@
+use rumqtt::{MqttClient, MqttOptions, QoS};
+use tokio;
+
+#[tokio::main]
+async fn main() {
+    // Define MQTT options
+    let mqtt_options = MqttOptions::new("my-client-id", "127.0.0.1", 1883)
+        .set_keep_alive(5)
+        .set_clean_session(true);
+
+    // Create an MQTT client
+    let (mut client, _) = MqttClient::start(mqtt_options).unwrap();
+
+    // Subscribe to a topic
+    client.subscribe("bedroom/temperature", QoS::AtMostOnce).unwrap();
+
+    // Publish a message to a topic
+    client
+        .publish("bedroom/temperature", QoS::AtMostOnce, false, "2".as_bytes())
+        .unwrap();
+
+    // Wait for incoming messages (you might want to use a loop here)
+    // if let Some(message) = client.incoming().await.next().await {
+    //     println!("Received message: {:?}", message);
+    // }
+
+    // Disconnect from the broker when done
+    // client.disconnect().await.unwrap();
+}

--- a/mqtt/rust-mosquitto/src/main.rs
+++ b/mqtt/rust-mosquitto/src/main.rs
@@ -13,6 +13,7 @@ fn main() {
     mqtt_client.subscribe(MQTT_TOPIC, QoS::AtLeastOnce).unwrap();
     let sleep_time = Duration::from_secs(1);
 
+                        .publish(MQTT_TOPIC, QoS::AtLeastOnce, false, payload)
     thread::spawn(move || {
         for i in 0..100 {
             let payload = format!("publish {}", i);

--- a/mqtt/rust-mosquitto/src/main.rs
+++ b/mqtt/rust-mosquitto/src/main.rs
@@ -1,4 +1,4 @@
-use rumqtt::{MqttClient, MqttOptions, QoS};
+use rumqtt::{MqttClient, MqttOptions, Notification, QoS};
 use std::{thread, time::Duration};
 
 const MQTT_CLIENT_ID: &str = "test-pubsub1";
@@ -6,11 +6,13 @@ const MQTT_ADDRESS: &str = "localhost";
 const MQTT_PORT: u16 = 1883;
 const MQTT_TOPIC: &str = "bedroom/temperature";
 
-fn main() {
+fn connect_to_mqtt() -> Result<(MqttClient, rumqtt::Receiver<Notification>), rumqtt::ConnectError> {
     let mqtt_options = MqttOptions::new(MQTT_CLIENT_ID, MQTT_ADDRESS, MQTT_PORT);
+    MqttClient::start(mqtt_options)
+}
 
-    // let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
-    match MqttClient::start(mqtt_options) {
+fn main() {
+    match connect_to_mqtt() {
         Ok((mut mqtt_client, notifications)) => {
             mqtt_client.subscribe(MQTT_TOPIC, QoS::AtLeastOnce).unwrap();
             let sleep_time = Duration::from_secs(1);

--- a/mqtt/rust-mosquitto/src/main.rs
+++ b/mqtt/rust-mosquitto/src/main.rs
@@ -8,23 +8,29 @@ const MQTT_TOPIC: &str = "bedroom/temperature";
 
 fn main() {
     let mqtt_options = MqttOptions::new(MQTT_CLIENT_ID, MQTT_ADDRESS, MQTT_PORT);
-    let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
 
-    mqtt_client.subscribe(MQTT_TOPIC, QoS::AtLeastOnce).unwrap();
-    let sleep_time = Duration::from_secs(1);
+    // let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
+    match MqttClient::start(mqtt_options) {
+        Ok((mut mqtt_client, notifications)) => {
+            mqtt_client.subscribe(MQTT_TOPIC, QoS::AtLeastOnce).unwrap();
+            let sleep_time = Duration::from_secs(1);
 
+            thread::spawn(move || {
+                for i in 0..100 {
+                    let payload = format!("publish {}", i);
+
+                    thread::sleep(sleep_time);
+
+                    mqtt_client
                         .publish(MQTT_TOPIC, QoS::AtLeastOnce, false, payload)
-    thread::spawn(move || {
-        for i in 0..100 {
-            let payload = format!("publish {}", i);
-            thread::sleep(sleep_time);
-            mqtt_client
-                .publish("bedroom/temperature", QoS::AtLeastOnce, false, payload)
-                .unwrap();
-        }
-    });
+                        .unwrap();
+                }
+            });
 
-    for notification in notifications {
-        println!("{:?}", notification)
+            for notification in notifications {
+                println!("{:?}", notification)
+            }
+        }
+        Err(e) => println!("error: {:?}", e),
     }
 }

--- a/mqtt/rust-mosquitto/src/main.rs
+++ b/mqtt/rust-mosquitto/src/main.rs
@@ -1,18 +1,25 @@
 use rumqtt::{MqttClient, MqttOptions, QoS};
 use std::{thread, time::Duration};
 
+const MQTT_CLIENT_ID: &str = "test-pubsub1";
+const MQTT_ADDRESS: &str = "localhost";
+const MQTT_PORT: u16 = 1883;
+const MQTT_TOPIC: &str = "bedroom/temperature";
+
 fn main() {
-    let mqtt_options = MqttOptions::new("test-pubsub1", "localhost", 1883);
+    let mqtt_options = MqttOptions::new(MQTT_CLIENT_ID, MQTT_ADDRESS, MQTT_PORT);
     let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
 
-    mqtt_client.subscribe("bedroom/temperature", QoS::AtLeastOnce).unwrap();
+    mqtt_client.subscribe(MQTT_TOPIC, QoS::AtLeastOnce).unwrap();
     let sleep_time = Duration::from_secs(1);
 
     thread::spawn(move || {
         for i in 0..100 {
             let payload = format!("publish {}", i);
             thread::sleep(sleep_time);
-            mqtt_client.publish("bedroom/temperature", QoS::AtLeastOnce, false, payload).unwrap();
+            mqtt_client
+                .publish("bedroom/temperature", QoS::AtLeastOnce, false, payload)
+                .unwrap();
         }
     });
 

--- a/mqtt/rust-mosquitto/src/main.rs
+++ b/mqtt/rust-mosquitto/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
 
             thread::spawn(move || {
                 for i in 0..100 {
-                    let payload = format!("publish {}", i);
+                    let payload = format!("Publish: {}", i);
 
                     thread::sleep(sleep_time);
 
@@ -30,9 +30,9 @@ fn main() {
             });
 
             for notification in notifications {
-                println!("{:?}", notification)
+                println!("Notification: {:?}", notification)
             }
         }
-        Err(e) => println!("error: {:?}", e),
+        Err(e) => println!("Error: {:?}", e),
     }
 }

--- a/mqtt/rust-mosquitto/src/main.rs
+++ b/mqtt/rust-mosquitto/src/main.rs
@@ -1,29 +1,22 @@
 use rumqtt::{MqttClient, MqttOptions, QoS};
-use tokio;
+use std::{thread, time::Duration};
 
-#[tokio::main]
-async fn main() {
-    // Define MQTT options
-    let mqtt_options = MqttOptions::new("my-client-id", "127.0.0.1", 1883)
-        .set_keep_alive(5)
-        .set_clean_session(true);
+fn main() {
+    let mqtt_options = MqttOptions::new("test-pubsub1", "localhost", 1883);
+    let (mut mqtt_client, notifications) = MqttClient::start(mqtt_options).unwrap();
 
-    // Create an MQTT client
-    let (mut client, _) = MqttClient::start(mqtt_options).unwrap();
+    mqtt_client.subscribe("bedroom/temperature", QoS::AtLeastOnce).unwrap();
+    let sleep_time = Duration::from_secs(1);
 
-    // Subscribe to a topic
-    client.subscribe("bedroom/temperature", QoS::AtMostOnce).unwrap();
+    thread::spawn(move || {
+        for i in 0..100 {
+            let payload = format!("publish {}", i);
+            thread::sleep(sleep_time);
+            mqtt_client.publish("bedroom/temperature", QoS::AtLeastOnce, false, payload).unwrap();
+        }
+    });
 
-    // Publish a message to a topic
-    client
-        .publish("bedroom/temperature", QoS::AtMostOnce, false, "2".as_bytes())
-        .unwrap();
-
-    // Wait for incoming messages (you might want to use a loop here)
-    // if let Some(message) = client.incoming().await.next().await {
-    //     println!("Received message: {:?}", message);
-    // }
-
-    // Disconnect from the broker when done
-    // client.disconnect().await.unwrap();
+    for notification in notifications {
+        println!("{:?}", notification)
+    }
 }


### PR DESCRIPTION
This PR adds an example that could help to subscribe and publish to a MQTT broker.

To test it, we used eclipse-mosquitto running a MQTT broker, and we subscribed with a client to the topic to test that the script works as expected.

The first step is opening a terminal and run the mosquitto broker:

```bash
mosquitto
```

After that, we use a mqtt client to subscribe to the example topic:

```bash
mosquitto_sub -h localhost -t 'bedroom/temperature'
```

Finally, build and run the rust script (located [here](https://github.com/traceable-chain/Research/tree/f7cf7a6a384f2ab09d33e4c275a19e89f7396c02/mqtt/rust-mosquitto)):

```bash
cargo build
./target/debug/rust-mosquitto
```

Closes #3 