### PR TITLE
5 run mqtt mosquitto broker from dockerfile

### DIFF
--- a/mqtt/rust-mosquitto/Dockerfile
+++ b/mqtt/rust-mosquitto/Dockerfile
@@ -1,0 +1,5 @@
+# Use the official Mosquitto image
+FROM eclipse-mosquitto:latest
+
+# Expose MQTT port
+EXPOSE 1883

--- a/mqtt/rust-mosquitto/src/main.rs
+++ b/mqtt/rust-mosquitto/src/main.rs
@@ -2,7 +2,7 @@ use rumqtt::{MqttClient, MqttOptions, Notification, QoS};
 use std::{thread, time::Duration};
 
 const MQTT_CLIENT_ID: &str = "test-pubsub1";
-const MQTT_ADDRESS: &str = "localhost";
+const MQTT_ADDRESS: &str = "172.17.0.2";
 const MQTT_PORT: u16 = 1883;
 const MQTT_TOPIC: &str = "bedroom/temperature";
 


### PR DESCRIPTION
**DISCLAIMER**

When running the script as well as the docker container locally, I'm getting the following error:

```bash
Error: Io(Os { code: 113, kind: HostUnreachable, message: "No route to host" })
``` 

Wondering if the problem has something to do with the mosquitto image used. This [stack overflow post](https://stackoverflow.com/questions/66143452/unable-to-connect-from-outside-the-mosquitto-docker) describe the same problem, but I can't reach a solution yet.

Official docs: [Eclipse Mosquitto Docker Image](https://github.com/eclipse/mosquitto/blob/master/docker/2.0/README.md)  